### PR TITLE
fix: wp not found

### DIFF
--- a/templates/wordpress-cms/config/web/Dockerfile
+++ b/templates/wordpress-cms/config/web/Dockerfile
@@ -8,6 +8,13 @@ RUN mv "$PHP_INI_DIR"/php.ini-development "$PHP_INI_DIR"/php.ini
 RUN apt-get update; \
 	apt-get install -yq mariadb-client netcat sudo less
 
+# wp-cli
+RUN curl -sL https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar -o wp; \
+	chmod +x wp; \
+	mv wp /usr/local/bin/; \
+	mkdir /var/www/.wp-cli; \
+	chown www-data:www-data /var/www/.wp-cli
+
 # ensure wordpress has write permission on linux host https://github.com/postlight/headless-wp-starter/issues/202
 RUN chown -R www-data:www-data /var/www/html
 


### PR DESCRIPTION
Addresses issue #9 : WP-CLI binary not found on wordpress-cms template